### PR TITLE
build(deps-dev): add Perl (CPAN) support to Dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+  - package-ecosystem: "cpan"  # Add Perl (CPAN) support
+    directory: "/"           # Update Perl dependencies in the root directory
+    schedule:
+      interval: "weekly"     # Adjust frequency if needed


### PR DESCRIPTION
This commit enhances the Dependabot configuration to include automatic updates for Perl (CPAN) modules. Dependabot will now scan the project for outdated Perl modules listed in the `cpanfile` or `cpanfile.snapshot` and create pull requests to keep them up-to-date.

This change ensures that both GitHub Actions and Perl dependencies are managed consistently, promoting better project maintainability and security.